### PR TITLE
rm dep on DBD::SQLite and DBD::Pg

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -14,8 +14,6 @@ my $builder = Module::Build->new(
         'File::Slurp' => 0,
     },
     requires => {
-        'DBD::SQLite' => 0,
-        'DBD::Pg'     => 0,
         'Digest::MD5' => 0,
         'File::Copy::Recursive' => 0,
         'Sub::Exporter' => 0,


### PR DESCRIPTION
As far as I can tell we aren't actually using DBI and the app actually using M::B::D might not be using DBD::Pg or DBD::SQLite to access the database (might be using DBD::PgPP or Pg, and it is almost certainly not using both postgres and SQLite).
