### PR TITLE
Better testing coverage for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: perl
 
+addons:
+  postgresql: "9.3"
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install postgresql-plperl-9.3
+  - sudo apt-get install postgresql-plperl-9.1
+
 script:
   - perl Build.PL
   - ./Build
@@ -10,3 +18,6 @@ perl:
   - "5.16"
   - "5.12"
 
+env:
+  - TEST_PLPERL=1 TEST_POSTGIS_BASE=/usr/share/postgresql/9.3/contrib/postgis-2.1 MBD_SCRATCH_PGHOST=localhost MBD_SCRATCH_PGPORT=5432
+  - TEST_PLPERL=1 TEST_POSTGIS_BASE=/usr/share/postgresql/9.3/contrib/postgis-2.1

--- a/t/01-install-postgis.t
+++ b/t/01-install-postgis.t
@@ -70,7 +70,11 @@ $ENV{PGDATABASE} = "scooby";
 sysok("$Module::Build::Database::PostgreSQL::Bin{Initdb} -D $dbdir");
 
 open my $fp, ">> $dbdir/postgresql.conf" or die $!;
-print {$fp} qq[unix_socket_directory = '$dbdir'\n];
+if ($pg_version[1] > 2) {
+    print {$fp} qq[unix_socket_directories = '$dbdir'\n];
+} else  {
+    print {$fp} qq[unix_socket_directory = '$dbdir'\n];
+}
 close $fp or die $!;
 
 sysok(qq[$Module::Build::Database::PostgreSQL::Bin{Pgctl} -t 120 -o "-h ''" -w start]);


### PR DESCRIPTION
This improves the testing coverage by PostgreSQL to include optional PostGIS and plperl tests, in addition to testing MBD_SCRATCH_PG\* environment variables.

I also had to tweak the PostGIS and plperl tests to work with PostgreSQL 9.3

I will send you at least two more PRs as I complete them:
1. Tests need to work when MBD_SCRATCH_ is defined but no postgres server binaries
2. Documentation for MBD_SCRATCH

So please wait for them before doing a release.
