### PR TITLE
migrate to container based ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: perl
+sudo: false
 
 addons:
   postgresql: "9.4"
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install postgresql-plperl-9.4
+  apt:
+    packages:
+      - postgresql-plperl-9.4
 
 script:
   - perl Build.PL
@@ -14,6 +14,7 @@ script:
   - ./Build install
 
 perl:
+  - "5.20"
   - "5.16"
   - "5.12"
 


### PR DESCRIPTION
See here for the advantages of using the container based infrastructure on traivs:

https://docs.travis-ci.com/user/migrating-from-legacy/

I also added 5.20 to the list of Perls to be tested since that is the version that we are using on our newer 64bit systems. 