### PR TITLE
Fix param name logic for unix_socket_dir in tests...

### DIFF
--- a/t/02-install-no-postgis.t
+++ b/t/02-install-no-postgis.t
@@ -29,6 +29,8 @@ $> or $^O eq 'MSWin32' or do {
 
 my @pg_version;
 
+my $pg_unix_socket_dir_param_name;
+
 if($scratch_db_server && $test_db_server) {
 
     if($Module::Build::Database::PostgreSQL::Bin{Psql}  eq '/bin/false') {
@@ -52,12 +54,19 @@ if($scratch_db_server && $test_db_server) {
     if ($pg_version[0]==8 && $pg_version[1] < 4) {
         plan skip_all => "postgres version must be >= 8.4"
     }
+
+    #pg changed the unix_socket_directory parameter name in 9.3, but Red Hat backports to 9.0
+    #See http://dba.stackexchange.com/questions/50135#50714
+    ($pg_unix_socket_dir_param_name) = `$Module::Build::Database::PostgreSQL::Bin{Postgres} --describe-config` =~
+        /^\W*(unix_socket_director(y|ies)\b)/m or die;
+
+    note "pg is using server parameter: $pg_unix_socket_dir_param_name";
+
 }
 
 plan qw/no_plan/;
 
 my $debug = 0;
-
 my $dir = tempdir( CLEANUP => !$debug);
 my $src_dir = "$FindBin::Bin/../eg/PgappNoPostgis";
 mkpath "$dir/db/patches";
@@ -110,11 +119,7 @@ if($test_db_server) {
     sysok("$Module::Build::Database::PostgreSQL::Bin{Initdb} -D $dbdir");
 
     open my $fp, ">> $dbdir/postgresql.conf" or die $!;
-    if ($pg_version[1] > 2) {
-        print {$fp} qq[unix_socket_directories = '$dbdir'\n];
-    } else  {
-        print {$fp} qq[unix_socket_directory = '$dbdir'\n];
-    }
+    print {$fp} qq[$pg_unix_socket_dir_param_name = '$dbdir'\n];
     close $fp or die $!;
 
     sysok(qq[$Module::Build::Database::PostgreSQL::Bin{Pgctl} -t 120 -o "-h ''" -w start]);


### PR DESCRIPTION
Under pg version 9.2.18 on Centos 7.3, the test throws the error:
    unrecognized configuration parameter "unix_socket_directory"

It turns out that RedHat backported the unix_socket_directories parameter
change back to pg 9.0, so doing a version check before writing to the
postgresql.conf doesn't work under those distros.

See http://dba.stackexchange.com/questions/50135#50714 for more info.